### PR TITLE
fix(in-app-messaging): conditionally call inAppMessagesHandler

### DIFF
--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -180,7 +180,11 @@ class NotificationsClass {
 				return pluggable.processInAppMessages(messages, event);
 			})
 		);
-		this.inAppMessagesHandler(flatten(messages));
+
+		const flattenedMessages = flatten(messages);
+		if (flattenedMessages.length) {
+			this.inAppMessagesHandler(flattenedMessages);
+		}
 	};
 
 	private analyticsListener: HubCallback = ({ payload }: HubCapsule) => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- update `Notifications.invokeInAppMessages` to conditionally call `this.inAppMessagesHandler` only when the flattened value of `messages` has length greater than `0` to prevent clearing of `inAppMessages` from UI state on subsequent calls to `Notifications.invokeInAppMessages`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
Manually tested with sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
